### PR TITLE
Adiciona gráfico de AFN

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react' 
 import Graph from './components/Graph'
 
-import { createNFAObject, getNFAAlphabet, categorizeTransitionByState, createNFATable } from './converter'
+import { createNFAObject, createNFATable, categorizeTransitionByState } from './converter'
 
 // assets
 import './App.css'
@@ -10,15 +10,50 @@ let fileReader
 
 function App () {
   const [values, setValues] = useState(null)
+  const [NFATable, setNFATable] = useState({})
+  const [categorizedTransitions, setCategorizedTransitions] = useState({})
+  const [parsedNFAObject, setParsedNFAObject] = useState({})
+
+  const [NFANodes, setNFANodes] = useState([])
+  const [NFAEdges, setNFAEdges] = useState([])
+
 
   useEffect(() => {
-    values !== null && createNFAObject(values)
+    if(values !== null) { 
+      const {NFATable, categorizedTransitions, obj} = createNFAObject(values)
+      setNFATable(NFATable)
+      setCategorizedTransitions(categorizedTransitions)
+      setParsedNFAObject(obj)
+      parseNFAGraphNodes(obj)
+    }
   }, [values])
+
+/*   useEffect(() => {
+    if(parsedNFAObject !== undefined) {
+      parseNFAGraphNodes(parsedNFAObject)
+    }
+  }, [NFANodes]) */
 
   function handleFileRead () {
     const content = fileReader.result
     setValues(content)
   }
+
+  function parseNFAGraphNodes(parsedNFAObject) {
+    const nodes = parsedNFAObject.transitions.map(transition => {
+      return {
+        id: transition,
+        label: transition,
+        color: "#000",
+        size: 10
+      }
+    })
+    setNFANodes(nodes)
+  }
+
+  console.log('nfa nodes.......... ', NFANodes)
+
+  //function parseNFAGraphEdges()
 
   function handleChange(file) {
     fileReader = new FileReader()
@@ -30,9 +65,12 @@ function App () {
     <div className='app'>
       <div className='app-header'>
       <Graph />
+      <Graph />
         <form>
-          <label htmlFor='file-upload'>Upload NFA</label>
-          <input onChange={evt => handleChange(evt.target.files[0])} type='file' id='file-upload' />
+          <div className='app-form'>
+            <label htmlFor='file-upload'>Upload NFA</label>
+            <input className='app-file-upload-button' onChange={evt => handleChange(evt.target.files[0])} type='file' id='file-upload' />
+          </div>
         </form>
         {values !== null && <p style={{ maxWidth: '200px' }}>{values}</p>}
       </div>

--- a/src/App.js
+++ b/src/App.js
@@ -24,8 +24,13 @@ function App () {
       setCategorizedTransitions(categorizedTransitions)
       setParsedNFAObject(obj)
       parseNFAGraphNodes(NFATable)
+
     }
   }, [values])
+
+  useEffect(() => {
+    parseNFAGraphEdges(NFATable, NFANodes)
+  }, [NFANodes])
 
   function handleFileRead () {
     const content = fileReader.result
@@ -44,7 +49,22 @@ function App () {
     setNFANodes(nodes)
   }
 
-  //function parseNFAGraphEdges()
+  function parseNFAGraphEdges(NFATable, NFANodes) {
+    const NFAEdges = Object.keys(NFATable).map(alphabet => {
+      return NFATable[alphabet].map(transitionObj => {
+        return {
+          id: `${transitionObj.transition} ${alphabet}`,
+          source: transitionObj.transition,
+          target: transitionObj.state !== 'Y' ? transitionObj.state : '',
+          label: `${transitionObj.transition} ${alphabet}`
+        }
+      })
+    }).flat()
+    console.log('NFA Table.................... ', NFATable)
+    console.log('NFA ndes............... ', NFANodes)
+
+    console.log('NFA aEDGES.............. ', NFAEdges)
+  }
 
   function handleChange(file) {
     fileReader = new FileReader()

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,6 @@ function App () {
   const [NFANodes, setNFANodes] = useState([])
   const [NFAEdges, setNFAEdges] = useState([])
 
-
   useEffect(() => {
     if(values !== null) { 
       const {NFATable, categorizedTransitions, obj} = createNFAObject(values)
@@ -27,12 +26,6 @@ function App () {
       parseNFAGraphNodes(obj)
     }
   }, [values])
-
-/*   useEffect(() => {
-    if(parsedNFAObject !== undefined) {
-      parseNFAGraphNodes(parsedNFAObject)
-    }
-  }, [NFANodes]) */
 
   function handleFileRead () {
     const content = fileReader.result

--- a/src/App.js
+++ b/src/App.js
@@ -51,6 +51,7 @@ function App () {
     setNFANodes(nodes)
   }
 
+
   console.log('nfa nodes.......... ', NFANodes)
 
   //function parseNFAGraphEdges()

--- a/src/App.js
+++ b/src/App.js
@@ -60,10 +60,7 @@ function App () {
         }
       })
     }).flat()
-    console.log('NFA Table.................... ', NFATable)
-    console.log('NFA ndes............... ', NFANodes)
-
-    console.log('NFA aEDGES.............. ', NFAEdges)
+    setNFAEdges(NFAEdges)
   }
 
   function handleChange(file) {
@@ -75,8 +72,8 @@ function App () {
   return (
     <div className='app'>
       <div className='app-header'>
-      <Graph />
-      <Graph />
+      {NFANodes.length > 0 && NFAEdges.length > 0 && <Graph nodes={NFANodes} edges={NFAEdges}/> }
+      {/*  <Graph />*/}
         <form>
           <div className='app-form'>
             <label htmlFor='file-upload'>Upload NFA</label>

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ function App () {
       setNFATable(NFATable)
       setCategorizedTransitions(categorizedTransitions)
       setParsedNFAObject(obj)
-      parseNFAGraphNodes(obj)
+      parseNFAGraphNodes(NFATable)
     }
   }, [values])
 
@@ -32,8 +32,8 @@ function App () {
     setValues(content)
   }
 
-  function parseNFAGraphNodes(parsedNFAObject) {
-    const nodes = parsedNFAObject.transitions.map(transition => {
+  function parseNFAGraphNodes(NFATable) {
+    const nodes = NFATable[0].map(({transition}) => {
       return {
         id: transition,
         label: transition,
@@ -43,9 +43,6 @@ function App () {
     })
     setNFANodes(nodes)
   }
-
-
-  console.log('nfa nodes.......... ', NFANodes)
 
   //function parseNFAGraphEdges()
 

--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Sigma} from 'react-sigma'
 
-const Graph = ({nodeName, edges, graphObject}) => {
+const Graph = ({nodes, edges }) => {
 
     /* TODO:
         https://codesandbox.io/s/349znkyn21?from-embed
@@ -90,7 +90,7 @@ const Graph = ({nodeName, edges, graphObject}) => {
         <Sigma 
         renderer="canvas"
         settings={settings}
-        style={{width: "1000px", height:"600px", backgroundColor: "#fff", display:"flex"}}
+        style={{ margin: '2rem',width: "1000px", height:"600px", backgroundColor: "#fff", display:"flex"}}
         graph={graphData}>
 
         </Sigma>

--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -10,11 +10,14 @@ const Graph = ({nodes, edges }) => {
         Check how the edges are labeled
     */
     const graphData = {
-        nodes: [],
-        edges: []
+      nodes,
+      edges
     }
+
+    console.log('graph data.................. ', graphData)
+    
     // mocked data
-    graphData.nodes.push({
+/*     graphData.nodes.push({
         id: "user",
         label: "Vasanth",
         x: 5,
@@ -66,15 +69,13 @@ const Graph = ({nodes, edges }) => {
         borderColor: "#FF3333",
 
       })
-
+ */
     return (
         <Sigma 
-        renderer="canvas"
-        settings={GRAPH_SETTINGS}
-        style={{ margin: '2rem',width: "1000px", height:"600px", backgroundColor: "#fff", display:"flex"}}
-        graph={graphData}>
-
-        </Sigma>
+          renderer="canvas"
+          settings={GRAPH_SETTINGS}
+          style={{ margin: '2rem',width: "1000px", height:"600px", backgroundColor: "#fff", display:"flex"}}
+          graph={graphData} />
     )
 };
 

--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Sigma} from 'react-sigma'
+import {GRAPH_SETTINGS} from '../helpers/constants'
 
 const Graph = ({nodes, edges }) => {
 
@@ -12,27 +13,6 @@ const Graph = ({nodes, edges }) => {
         nodes: [],
         edges: []
     }
-
-    const settings = {
-        batchEdgesDrawing: true,
-        drawEdges: true,
-        drawLabels: true,
-        drawEdgeLabels: true,
-        hideEdgesOnMove: false,
-        animationsTime: 3000,
-        clone: false,
-        doubleClickEnabled: true,
-        mouseWheelEnabled: true,
-        minNodeSize: 5,
-        maxNodeSize: 10,
-        minArrowSize: 2,
-        minEdgeSize: 0.5,
-        maxEdgeSize: 1,
-        defaultNodeBorderColor: "#000",
-        defaultHoverLabelBGColor: "transparent",
-        labelHoverColor: "transparent",
-        defaultLabelSize: 11
-    };
     // mocked data
     graphData.nodes.push({
         id: "user",
@@ -89,7 +69,7 @@ const Graph = ({nodes, edges }) => {
     return (
         <Sigma 
         renderer="canvas"
-        settings={settings}
+        settings={GRAPH_SETTINGS}
         style={{ margin: '2rem',width: "1000px", height:"600px", backgroundColor: "#fff", display:"flex"}}
         graph={graphData}>
 

--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -39,6 +39,7 @@ const Graph = ({nodes, edges }) => {
         id: "userEdge2",
         source: "device1",
         target: "user",
+        label: "hiiii",
         size: 3,
         color: "#ff0000",
         neighborsOf: "n" + ((Math.random() * 2) | 0),

--- a/src/converter.js
+++ b/src/converter.js
@@ -14,8 +14,10 @@ export const createNFAObject = (file) => {
   obj.transitions = transitions
   const categorizedTransitions = categorizeTransitionByState(obj.alphabet);
   NFATable = createNFATable(categorizedTransitions, obj.transitions);
+  console.log('nfa table on converter.......... ', NFATable)
   const initialDFATable = getDFAInitialState(NFATable);
   const DFATable = createDFATable(initialDFATable, NFATable)
+  return {NFATable, categorizedTransitions, obj}
   // const DFATransitions = DFATransitionsArray(DFATable)
   // getNextDFAState(DFATransitions, NFATable, obj.alphabet.split(' ').join(''))
 }
@@ -23,7 +25,7 @@ export const createNFAObject = (file) => {
 function createDFATable(initialDFATable, NFATable) {
   let transitionArray = [initialDFATable[0][0].transition]
   Object.keys(initialDFATable).forEach(key => {
-    initialDFATable[key].map(transitionItem => {
+    initialDFATable[key].forEach(transitionItem => {
       if (foundItemInsideArray(transitionArray, initialDFATable[key], 'state').length === 0) {
         transitionArray.push(transitionItem.state)
         insertNewDFAItem(initialDFATable, transitionItem.state)
@@ -60,7 +62,7 @@ function insertNewDFAItem (initialDFATable, itemToBeInserted) {
     }
   })
 
-  Object.keys(initialDFATable).map(key => {
+  Object.keys(initialDFATable).forEach(key => {
     initialDFATable[key].push({
       transition: itemToBeInserted,
       state: newState[key]

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -1,0 +1,20 @@
+export const GRAPH_SETTINGS = {
+    batchEdgesDrawing: true,
+    drawEdges: true,
+    drawLabels: true,
+    drawEdgeLabels: true,
+    hideEdgesOnMove: false,
+    animationsTime: 3000,
+    clone: false,
+    doubleClickEnabled: true,
+    mouseWheelEnabled: true,
+    minNodeSize: 5,
+    maxNodeSize: 10,
+    minArrowSize: 2,
+    minEdgeSize: 0.5,
+    maxEdgeSize: 1,
+    defaultNodeBorderColor: "#000",
+    defaultHoverLabelBGColor: "transparent",
+    labelHoverColor: "transparent",
+    defaultLabelSize: 11
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,18 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+.app-form {
+  display:  flex;
+  justify-content: center;
+  align-content: flex-end;
+  width: 100%;
+  height: 200px;
+  align-items: center;
+}
+
+.app-file-upload-button {
+  color: #333333;
+  border: none;
+  background-color: darkgray;
+}


### PR DESCRIPTION
Eu criei os objetos das arestas e dos nós no formato em que o SigmaJS aceita pra montar o gráfico. No caso, pros objetos dos array `NFAEdges` e `NFANodes`. As funções que criam esses array podem ser abstraídas pro AFD. Eu preciso passar e testar ainda os parametros de estilo pra cada nó e aresta pra exibir o gráfico. Cada nó e aresta, além de um id, label; e target e source (para o objeto de aresta), precisa de uma cor, tamanho e posição, como essse objeto:

     `graphData.nodes.push({`
        id: "device1",
        label: "Tablet",
        x: 1,
        y: 10,
        size: 8,
        color: "#000000",
        borderColor: "#FF3333",
      })`